### PR TITLE
update: clean up status codes

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,7 +6,8 @@ import (
 )
 
 var (
-	ErrTooManyRequests = errors.New("too many requests")
+	ErrTooManyRequests      = errors.New("too many requests")
+	ErrUnexpectedStatusCode = errors.New("unexpected status code")
 )
 
 // APIError is an API error.

--- a/job.go
+++ b/job.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -91,7 +92,7 @@ func (c *Client) CreateTTSJob(ctx context.Context, createReq *CreateTTSJobReq) (
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -135,7 +136,7 @@ func (c *Client) GetTTSJob(ctx context.Context, id string) (*TTSJob, error) {
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -179,7 +180,7 @@ func (c *Client) GetTTSJobAudioStream(ctx context.Context, w io.Writer, id strin
 		}
 		return apiErr
 	default:
-		return err
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -235,7 +236,7 @@ func (c *Client) CreateTTSJobWithProgressStream(ctx context.Context, w io.Writer
 		}
 		return "", apiErr
 	default:
-		return "", err
+		return "", fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -278,6 +279,6 @@ func (c *Client) GetTTSJobProgressStream(ctx context.Context, w io.Writer, id st
 		}
 		return apiErr
 	default:
-		return err
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }

--- a/lease.go
+++ b/lease.go
@@ -97,7 +97,7 @@ func (c *Client) CreateLease(ctx context.Context, _ *CreateLeaseReq) (*Lease, er
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -106,7 +107,7 @@ func (c *Client) TTSStream(ctx context.Context, w io.Writer, createReq *CreateTT
 		}
 		return apiErr
 	default:
-		return err
+		return fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -158,6 +159,6 @@ func (c *Client) TTSStreamURL(ctx context.Context, createReq *CreateTTSStreamReq
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }

--- a/voices.go
+++ b/voices.go
@@ -103,7 +103,7 @@ func (c *Client) GetVoices(ctx context.Context) ([]Voice, error) {
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -146,7 +146,7 @@ func (c *Client) GetClonedVoices(ctx context.Context) ([]ClonedVoice, error) {
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -215,7 +215,7 @@ func (c *Client) CreateInstantVoiceCloneFromFile(ctx context.Context, cloneReq *
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -277,7 +277,7 @@ func (c *Client) CreateInstantVoiceCloneFromURL(ctx context.Context, cloneReq *C
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 
@@ -328,7 +328,7 @@ func (c *Client) DeleteClonedVoice(ctx context.Context, delReq *DeleteClonedVoic
 		}
 		return nil, apiErr
 	default:
-		return nil, err
+		return nil, fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
this is a preventive action to make sure we catch possible change of returned HTTP status codes as per the docs. We handle and deserialize all the errors as per the docs but when we receive 201 instead of 200 or some such we can end up being puzzled.