### PR TITLE
bugfix: fix response propagation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,4 +84,4 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v4
       with:
-        version: v1.56
+        version: v1.58

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
     - gofmt
     - revive
     - ineffassign
-    - vet
+    - govet
     - unused
     - misspell
     - bodyclose
@@ -13,12 +13,6 @@ linters:
     - goimports
     - prealloc
     - tparallel
-
-run:
-  deadline: 2m
-  # TODO: remove this once GHA is updated
-  skip-dirs:
-    - vendor
 
 issues:
   exlude-dirs:

--- a/request/request.go
+++ b/request/request.go
@@ -57,10 +57,14 @@ func Do[T error](client *client.HTTP, req *http.Request) (*http.Response, error)
 	}
 	defer resp.Body.Close()
 
+	buf := &bytes.Buffer{}
+	body := io.TeeReader(resp.Body, buf)
+
 	var apiErr T
-	if jsonErr := json.NewDecoder(resp.Body).Decode(&apiErr); jsonErr != nil {
+	if jsonErr := json.NewDecoder(body).Decode(&apiErr); jsonErr != nil {
 		// NOTE: return the original error
-		return nil, err
+		resp.Body = io.NopCloser(buf)
+		return resp, err
 	}
 
 	return nil, apiErr


### PR DESCRIPTION
Unfortunately, a small bug snuck in: when we fail to decode error into API error we do not propagate the response up the stack.

We also update a linter in this PR